### PR TITLE
Improve beatPrevious and refactor import

### DIFF
--- a/server/beatPrevious.py
+++ b/server/beatPrevious.py
@@ -4,6 +4,14 @@ class BeatPrevious:
         if(not len(enemyHistory)):
             return "r"
 
-        last = enemyHistory[-1]
+        enemyLast = enemyHistory[-1]
+        selfLast = selfHistory[-1]
+
         opposing = {"r": "p","p": "s","s": "r"}
-        return opposing[last]
+
+        # if opponent just lost, expect them to switch to beat your previous move
+        if (selfLast == opposing[enemyLast]):
+            return enemyLast
+        else:
+            return opposing[enemyLast]
+

--- a/server/server.py
+++ b/server/server.py
@@ -1,6 +1,6 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
-from server.nn import NN
+from nn import NN
 
 app = Flask(__name__)
 app.config.from_object(__name__) # load config from this file


### PR DESCRIPTION
Super short change because I was trying to get familiar with your code! Now if the player beats the opponent in the previous round, instead of trying to just beat what they played last turn, expect them to try to beat what you just beat them with. (Basically, just expect that they are using beatPrevious as well)

Example: Rock beats Scissors, next round simply play Scissors (mirror what they just played if you win) because they will try to play Paper next turn.

This improves performance a decent amount against Probability

![selection_999 1327](https://user-images.githubusercontent.com/11599574/44306172-76256300-a346-11e8-9011-bfb8b35da139.png)
![selection_999 1326](https://user-images.githubusercontent.com/11599574/44306173-77ef2680-a346-11e8-96a5-787cb3450660.png)

Thanks to https://motherboard.vice.com/en_us/article/gvym4x/game-theory-rock-paper-scissors

(Not sure why I wrote such a long PR for 8 lines changed but no biggie)